### PR TITLE
Prevent build service global.

### DIFF
--- a/shorthand-ceros/header-footer.js
+++ b/shorthand-ceros/header-footer.js
@@ -73,7 +73,7 @@ function replaceTooltipSponsor($) {
 function getTrackingPageOptions(uuid) {
   return `
   {
-    content: { 
+    content: {
       ${uuid ? `uuid: '${uuid}',` : ''}
       asset_type: 'page'
     }
@@ -161,7 +161,7 @@ function _buildOrigamiUrl(modules, type) {
     return module.version ? `${module.name}@^${module.version}` : module.name;
   });
 
-  return `https://www.ft.com/__origami/service/build/v2/bundles/${type}?modules=${modulesWithVersion.join(',')}${ type === 'js' ? '&autoinit=0' : ''}`;
+  return `https://www.ft.com/__origami/service/build/v2/bundles/${type}?modules=${modulesWithVersion.join(',')}${type === 'js' ? '&autoinit=0&export=""' : ''}`;
 }
 
 module.exports = ($, args) => {

--- a/shorthand-ceros/snippets/footer-scripts.js
+++ b/shorthand-ceros/snippets/footer-scripts.js
@@ -24,7 +24,7 @@ module.exports = (origamiScriptUrl, trackingPageOptions) => `<script id="ft-js">
 				}
 			}
 		}
-		
+
 		function oTrackinginit() {
           // oTracking
           var oTracking = Origami['o-tracking'];
@@ -73,7 +73,7 @@ module.exports = (origamiScriptUrl, trackingPageOptions) => `<script id="ft-js">
 				}
 			});
 		}
-		
+
 		// Need to make some changes to the DOM before initialising the
     // origami components so we fire off the o.DOMContentLoaded when
     // we're ready.
@@ -106,7 +106,7 @@ module.exports = (origamiScriptUrl, trackingPageOptions) => `<script id="ft-js">
 			}
 			s.parentNode.insertBefore(o, s);
 		}
-		
+
 		// The mustard is NOT cut
 		else {
 		  // Add fallback if browsers don't cut the mustard -->


### PR DESCRIPTION
Quick hack to prevent the default global `Origami` object from being output, instead the Origami object created from the ingested html will be available, as this PR appears not to work. https://github.com/Financial-Times/shorthand-lambda/pull/6. 

This is not okay as only one build service request should be made ideally.