### PR TITLE
Remove custom OBS export.

### DIFF
--- a/shorthand-ceros/header-footer.js
+++ b/shorthand-ceros/header-footer.js
@@ -161,7 +161,7 @@ function _buildOrigamiUrl(modules, type) {
     return module.version ? `${module.name}@^${module.version}` : module.name;
   });
 
-  return `https://www.ft.com/__origami/service/build/v2/bundles/${type}?modules=${modulesWithVersion.join(',')}${type === 'js' ? '&export=OrigamiDefault' : ''}`;
+  return `https://www.ft.com/__origami/service/build/v2/bundles/${type}?modules=${modulesWithVersion.join(',')}`;
 }
 
 module.exports = ($, args) => {

--- a/shorthand-ceros/header-footer.spec.js
+++ b/shorthand-ceros/header-footer.spec.js
@@ -34,7 +34,7 @@ describe('headerFooter', () => {
 
     it('adds the paid-post banner with a tooltip', () => {
       return headerFooter($, ArgsFixture).then(result => {
-        expect(result('#disclaimer').is('section')).to.be.true;
+        expect(result('#disclaimer').is('div')).to.be.true;
         expect(result('#paid-post-tooltip').attr('data-o-component')).to.equal('o-tooltip');
         expect(result('.o-tooltip-content').is('div')).to.be.true;
       });

--- a/shorthand-ceros/header-footer.spec.js
+++ b/shorthand-ceros/header-footer.spec.js
@@ -98,7 +98,7 @@ describe('headerFooter', () => {
 
       return headerFooter($, ArgsFixture).then(result => {
         expect(result('head').html()).to.include('https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-grid@^4.3.3,o-header@^7.0.4,o-footer@^6.0.2,o-typography@^5.1.1,o-colors@^4.1.1,o-tooltip@^2.2.3,o-fonts@^3.0.1,o-share@^6.0.1,o-gallery@^3.0.2,o-normalise@^1.5.1,o-overlay@^2.1.4,o-buttons');
-        expect(result('body').text()).to.include('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.3.3,o-header@^7.0.4,o-footer@^6.0.2,o-typography@^5.1.1,o-colors@^4.1.1,o-tooltip@^2.2.3,o-tracking,o-fonts@^3.0.1,o-share@^6.0.1,o-gallery@^3.0.2,o-normalise@^1.5.1,o-overlay@^2.1.4,o-buttons&export=OrigamiDefault');
+        expect(result('body').text()).to.include('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.3.3,o-header@^7.0.4,o-footer@^6.0.2,o-typography@^5.1.1,o-colors@^4.1.1,o-tooltip@^2.2.3,o-tracking,o-fonts@^3.0.1,o-share@^6.0.1,o-gallery@^3.0.2,o-normalise@^1.5.1,o-overlay@^2.1.4,o-buttons');
       });
     });
   });

--- a/shorthand-ceros/snippets/footer-scripts.js
+++ b/shorthand-ceros/snippets/footer-scripts.js
@@ -27,7 +27,7 @@ module.exports = (origamiScriptUrl, trackingPageOptions) => `<script id="ft-js">
 
 		function oTrackinginit() {
           // oTracking
-          var oTracking = OrigamiDefault['o-tracking'];
+          var oTracking = Origami['o-tracking'];
           var sponsor = document.querySelector('meta[name="sponsor"]');
           var parent = document.querySelector('meta[name="parent"]');
           var config_data = {

--- a/shorthand-ceros/snippets/header-html.js
+++ b/shorthand-ceros/snippets/header-html.js
@@ -30,7 +30,7 @@ module.exports = `
 		</div>
 	</div>
 </header>
-<div class="o-grid-container disclaimer">
+<div id="disclaimer" class="o-grid-container disclaimer">
   <div class="disclaimer__box" id="paid-post-tooltip-target">
     <span class="disclaimer__paid-post">Paid Post</span>
     <span class="disclaimer__sponsor">[[REPLACED FROM META TAG WITH name="tooltip:sponsor" in uploaded page]]</span>


### PR DESCRIPTION
Added as a hack to prevent conflicts with build service scripts which failed to merge to one request. Defaults to `Origami`.
https://www.ft.com/__origami/service/build/v2/#get-v1-bundles-js